### PR TITLE
Add registers for USBDevice low_speed_only, full_speed_only si…  …gnals

### DIFF
--- a/luna_soc/gateware/cpu/vexriscv.py
+++ b/luna_soc/gateware/cpu/vexriscv.py
@@ -85,7 +85,7 @@ class VexRiscv(CPU, Elaboratable):
         i_reset     = ResetSignal("sync") | self.ext_reset
 
         # instantiate VexRiscv
-        platform.add_file(self._source_path, self._source_verilog)
+        platform.add_file(self._source_file, self._source_verilog)
         self._cpu = Instance(
             "VexRiscv",
             # clock and reset


### PR DESCRIPTION
This PR adds registers to eptri's `USBDeviceController` for `USBDevice`'s `low_speed_only`, `full_speed_only` signals.

With bonus fix for recent amaranth change to `add_file`.