### PR TITLE
repo: bump amaranth-stdio to 4a14bb17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio@f41e7e5",
+    "amaranth-stdio @ git+https://github.com/amaranth-lang/amaranth-stdio@4a14bb17",
     "amaranth-soc @ git+https://github.com/amaranth-lang/amaranth-soc@d2185e3",
     "minerva @ git+https://github.com/minerva-cpu/minerva",
     "lambdasoc @ git+https://github.com/antoinevg/lambdasoc.git@antoinevg/support-vexriscv",


### PR DESCRIPTION
This PR bumps the `amaranth-stdio` dependency to [4a14bb17](https://github.com/amaranth-lang/amaranth-stdio/commit/4a14bb17c2c38374dc720473ee714247e8ae6b8a)

This is the latest version that:

1. Does not pull in `amaranth` from git.
2. Also works with LambdaSoC.