### PR TITLE
eptri: fix update logic for OutFIFOInterface data_ep register

### DIFF
--- a/luna_soc/gateware/csr/usb2/interfaces/eptri.py
+++ b/luna_soc/gateware/csr/usb2/interfaces/eptri.py
@@ -716,7 +716,7 @@ class OutFIFOInterface(Peripheral, Elaboratable):
 
         # Whenever we capture data, update our associated endpoint number
         # to match the endpoint on which we received the relevant data.
-        with m.If(fifo.w_en):
+        with m.If(token.new_token & token.is_out):
             m.d.usb += self.data_ep.r_data.eq(token.endpoint)
 
         # Whenever we ACK a non-redundant receive, toggle our DATA PID.


### PR DESCRIPTION
Previously `OutFIFOInterface`'s `data_ep` register would only get updated with the incoming packet's destination endpoint once the FIFO `w_en` signal was asserted.

The problem with this is that, under this condition, the register does not get updated upon receipt of a `ZLP` (zero-length packet).

The new logic updates the register on receipt of a new token.