### PR TITLE
README.md: libary -> library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LUNA-SOC: Amaranth HDL libary for building USB-capable SoC designs
+# LUNA-SOC: Amaranth HDL library for building USB-capable SoC designs
 
 ## LUNA-SOC Library
 


### PR DESCRIPTION
Was noticed when packaging this for nixpkgs - https://github.com/NixOS/nixpkgs/pull/353392#discussion_r1846219640

Same typo also exists in the about description of this repo
![image](https://github.com/user-attachments/assets/7bf109f2-77cd-4022-8afb-088123d598cc)