### PR TITLE
Fix ambiguous documentation and implementation for eptri ep_out priming behaviour

### DIFF
--- a/luna_soc/gateware/csr/usb2/interfaces/eptri.py
+++ b/luna_soc/gateware/csr/usb2/interfaces/eptri.py
@@ -528,8 +528,9 @@ class OutFIFOInterface(Peripheral, Elaboratable):
         """)
 
         self.epno = regs.csr(4, "rw", desc="""
-            Selects the endpoint number to prime. This interface only allows priming a single endpoint at once--
-            that is, only one endpoint can be ready to receive data at a time. See the `enable` bit for usage.
+            Selects the endpoint number to prime. This interface allows priming multiple endpoints at once--
+            that is, multiple endpoints can be ready to receive data at a time. See the `prime` and `enable` bits
+            for usage.
         """)
 
         self.enable = regs.csr(1, "rw", desc="""
@@ -634,12 +635,11 @@ class OutFIFOInterface(Peripheral, Elaboratable):
         with m.If(self.prime.w_stb):
             m.d.usb += endpoint_primed[self.epno.r_data].eq(self.prime.w_data)
 
-        # If we've just ACK'd a receive, clear our enable, un-prime the given endpoint and
+        # If we've just ACK'd a receive, clear our enable and
         # clear our FIFO's ready state.
         with m.If(interface.handshakes_out.ack & token.is_out):
             m.d.usb += [
                 self.enable.r_data                .eq(0),
-                endpoint_primed[token.endpoint]   .eq(0),
                 fifo_ready                        .eq(0),
             ]
 
@@ -676,16 +676,16 @@ class OutFIFOInterface(Peripheral, Elaboratable):
         #  - We've primed the relevant endpoint.
         #  - Our most recent token is an OUT.
         #  - We're not stalled.
-        stalled          = token.is_out & endpoint_stalled[token.endpoint]
-        endpoint_primed  = endpoint_primed[token.endpoint]
-        ready_to_receive = fifo_ready & endpoint_primed & self.enable.r_data & ~stalled
-        allow_receive    = token.is_out & ready_to_receive
-        nak_receives     = token.is_out & ~ready_to_receive & ~stalled
+        stalled            = token.is_out & endpoint_stalled[token.endpoint]
+        is_endpoint_primed = endpoint_primed[token.endpoint]
+        ready_to_receive   = fifo_ready & is_endpoint_primed & self.enable.r_data & ~stalled
+        allow_receive      = token.is_out & ready_to_receive
+        nak_receives       = token.is_out & ~ready_to_receive & ~stalled
 
         # Shortcut for when we have a "redundant"/incorrect PID. In these cases, we'll assume
         # the host missed our ACK, and per the USB spec, implicitly ACK the packet.
         is_redundant_pid    = (interface.rx_pid_toggle != endpoint_data_pid[token.endpoint])
-        is_redundant_packet = endpoint_primed & token.is_out & is_redundant_pid
+        is_redundant_packet = is_endpoint_primed & token.is_out & is_redundant_pid
 
         # Shortcut conditions under which we'll ACK and NAK a receive.
         ack_redundant_packet = (is_redundant_packet & interface.rx_ready_for_response)


### PR DESCRIPTION
This PR is part of:
* https://github.com/greatscottgadgets/cynthion/pull/203
* https://github.com/greatscottgadgets/facedancer/pull/124

---


The documentation and implementation for eptri's `OutFIFOInterface` when it comes to endpoint priming has been somewhat at odds.

To whit, the `epno` register documentation read:

> Selects the endpoint number to prime. This interface only allows priming a single endpoint at once -- that is, only one endpoint can be ready to receive data at a time. See the `enable` bit for usage.

While the `prime` register documentation read:

> Controls "priming" an out endpoint. To receive data on any endpoint, the CPU must first select the endpoint with the `epno` register; and then write a '1' into the prime and enable register. This prepares our FIFO to receive data; and the next OUT transaction will be captured into the FIFO.
>
> When a transaction is complete, the `enable` bit is reset; the `prime` is not. This effectively means that `enable` controls receiving on _any_ of the primed endpoints; while `prime` can be used to build a collection of endpoints willing to participate in receipt.
>
> Only one transaction / data packet is captured per `enable` write; repeated enabling is necessary to capture multiple packets.

The actual implementation in this case was in line with the `epno` register in that endpoints would be un-primed upon receipt of a packet and would need to be re-primed before further data would be received:

```python
# If we've just ACK'd a receive, clear our enable, un-prime the given endpoint and
# clear our FIFO's ready state.
with m.If(interface.handshakes_out.ack & token.is_out):
    m.d.usb += [
        self.enable.r_data                .eq(0),
        endpoint_primed[token.endpoint]   .eq(0),  # <==== unprime endpoint
        fifo_ready                        .eq(0),
    ]
```

In practice, the behaviour documented in the `prime` register is far more desirable as it removes the need for the firmware to keep track of re-priming endpoints and only requires that the interface be re-enabled after receipt of a packet on any endpoint.

This PR removes the ambiguity from the documentation and establishes the behaviour documented in the `prime` register.