### PR TITLE
Only set ep_control epno register if it's a setup packet.

### DIFF
--- a/luna_soc/gateware/csr/usb2/interfaces/eptri.py
+++ b/luna_soc/gateware/csr/usb2/interfaces/eptri.py
@@ -151,7 +151,7 @@ class SetupFIFOInterface(Peripheral, Elaboratable):
         # Status and interrupts.
         #
 
-        with m.If(token.new_token):
+        with m.If(token.new_token & token.is_setup):
             m.d.usb += self.epno.r_data.eq(token.endpoint)
 
         # TODO: generate interrupts


### PR DESCRIPTION
I'm not sure how this bug has managed to exist for so long without causing more problems, but this PR fixes a situation where incoming packets on other endpoints will change the value of the epno register on `SetupFIFOInterface`.
