### PR TITLE
eptri: OutFIFOInterface: fixes for concurrency issues

### DIFF
--- a/luna_soc/gateware/csr/usb2/interfaces/eptri.py
+++ b/luna_soc/gateware/csr/usb2/interfaces/eptri.py
@@ -653,8 +653,8 @@ class OutFIFOInterface(Peripheral, Elaboratable):
                 m.d.usb += endpoint_primed[token.endpoint].eq(0)
 
         # Mark our FIFO as ready iff it is enabled and primed on receipt of a new token.
-        with m.If(token.new_token & self.enable.r_data & endpoint_primed[token.endpoint]):
-            m.d.usb += fifo_ready.eq(1)
+        with m.If(token.new_token):
+            m.d.usb += fifo_ready.eq(self.enable.r_data & endpoint_primed[token.endpoint])
 
         # Set the value of our endpoint `stall` based on our `stall` register...
         with m.If(self.stall.w_stb):

--- a/luna_soc/gateware/csr/usb2/interfaces/eptri.py
+++ b/luna_soc/gateware/csr/usb2/interfaces/eptri.py
@@ -736,7 +736,7 @@ class OutFIFOInterface(Peripheral, Elaboratable):
 
         # Whenever we capture data, update our associated endpoint number
         # to match the endpoint on which we received the relevant data.
-        with m.If(token.new_token & token.is_out):
+        with m.If(token.new_token & token.is_out & self.enable.r_data):
             m.d.usb += self.data_ep.r_data.eq(token.endpoint)
 
         # Whenever we ACK a non-redundant receive, toggle our DATA PID.


### PR DESCRIPTION
Here are fixes for two concurrency issues I encountered while trying to use facedancer; see the commit messages for detail. (Note that the second one is _mainly_ only an issue if the firmware can prime an endpoint while the `OutFIFOInterface` is enabled, or if the firmware actively disables the `OutFIFOInterface` sometimes.)