### PR TITLE
eptri: latch ep_in token.endpoint until transfer has completed

### DIFF
--- a/luna_soc/gateware/csr/usb2/interfaces/eptri.py
+++ b/luna_soc/gateware/csr/usb2/interfaces/eptri.py
@@ -297,6 +297,10 @@ class InFIFOInterface(Peripheral, Elaboratable):
         with m.Elif(decrement & ~increment):
             m.d.usb += bytes_in_fifo.eq(bytes_in_fifo - 1)
 
+        # Latch token endpoint until all data is written out from the FIFO.
+        latched_endpoint = Signal(4)
+        with m.If(token.new_token & token.is_in & (~fifo.r_rdy)):
+            m.d.usb += latched_endpoint.eq(token.endpoint)
 
         #
         # Register updates.
@@ -354,11 +358,11 @@ class InFIFOInterface(Peripheral, Elaboratable):
         # Data toggle control.
         #
 
-        endpoint_matches = (token.endpoint == self.epno.r_data)
+        endpoint_matches = (latched_endpoint == self.epno.r_data)
         packet_complete  = self.interface.handshakes_in.ack & token.is_in & endpoint_matches
 
         # Always drive the DATA pid we're transmitting with our current data pid.
-        m.d.comb += self.interface.tx_pid_toggle.eq(endpoint_data_pid[token.endpoint])
+        m.d.comb += self.interface.tx_pid_toggle.eq(endpoint_data_pid[latched_endpoint])
 
         # If our controller is overriding the data PID, accept the override.
         with m.If(self.pid.w_stb):
@@ -366,7 +370,7 @@ class InFIFOInterface(Peripheral, Elaboratable):
 
         # Otherwise, toggle our expected DATA PID once we receive a complete packet.
         with m.Elif(packet_complete):
-            m.d.usb += endpoint_data_pid[token.endpoint].eq(~endpoint_data_pid[token.endpoint])
+            m.d.usb += endpoint_data_pid[latched_endpoint].eq(~endpoint_data_pid[latched_endpoint])
 
 
         #
@@ -375,7 +379,7 @@ class InFIFOInterface(Peripheral, Elaboratable):
 
         # Logic shorthand.
         new_in_token     = (token.is_in & token.ready_for_response)
-        stalled          = endpoint_stalled[token.endpoint]
+        stalled          = endpoint_stalled[latched_endpoint]
 
         with m.FSM(domain='usb') as f:
 
@@ -402,7 +406,7 @@ class InFIFOInterface(Peripheral, Elaboratable):
                 # This means we have data to send, but are just waiting for an IN token.
                 with m.If(self.epno.w_stb & ~stalled):
                     # we can also clear our NAK status now
-                    m.d.usb += endpoint_nakked[token.endpoint].eq(0)
+                    m.d.usb += endpoint_nakked[latched_endpoint].eq(0)
                     m.next = "PRIMED"
 
                 # Always return to IDLE on reset.
@@ -652,7 +656,8 @@ class OutFIFOInterface(Peripheral, Elaboratable):
             with m.If(token.endpoint == 0):
                 m.d.usb += endpoint_primed[token.endpoint].eq(0)
 
-        # Mark our FIFO as ready iff it is enabled and primed on receipt of a new token.
+        # On receipt of a new token, mark our FIFO as ready iff the peripheral is enabled
+        # and the destination endpoint for the token is primed.
         with m.If(token.new_token):
             m.d.usb += fifo_ready.eq(self.enable.r_data & endpoint_primed[token.endpoint])
 


### PR DESCRIPTION
In #40 we discover a reproducible test case that results in the following failure mode:

On the host side, we issue the following USB Request Blocks:

```c
while true {
  // send a vendor out request with 32 bytes of data to device on ep0
  USBDEVFS_URB_TYPE_CONTROL, USB_DIR_OUT, [32 bytes of data]
  
  // make a bulk in request for data from device on ep1
  USBDEVFS_URB_TYPE_BULK, USB_DIR_IN
  
  // send a vendor out request with 32 bytes of data to device on ep0
  USBDEVFS_URB_TYPE_CONTROL, USB_DIR_OUT, [32 bytes of data]
  
  // block until all three requests have completed
  USBDEVFS_REAPURB
  USBDEVFS_REAPURB
  USBDEVFS_REAPURB
}
```

This creates the following situation in eptri's `InFIFOInterface` on the device side, locking up the peripheral and rendering it incapable of continuing.

```
-- Vendor OUT ep0 - complete

+- Vendor OUT ep0
|
|  -- Bulk IN ep1 - complete
|
+-> complete

-- Vendor OUT ep0 - complete

+- Bulk IN ep1
|  All goes well, until Vendor makes a ZLP IN request and changes token.endpoint mid-transfer:
|  +- Vendor OUT ep0 - incomplete (firmware is tx_ack_active trying to send the Bulk IN so cannot ZLP)
|  |
+-> complete
```

This pull request modifies the behavior of `InFIFOInterface` to latch the `token.endpoint` until the current transaction has completed.
