### PR TITLE
[WIP] util/sim: add `VerilatorPlatform` simulation backend, migrate away from `make`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,17 @@
 # Build outputs
 **/scala/project/target/
 **/scala/target/
+**/lunasoc-pac/src/generated/*
+**/lunasoc-pac/src/generated.rs
+**/lunasoc-pac/device.x
 memory.x
 applets/**/build/
 examples/**/build/
 *.bit
+*.svd
+*.fst
+*.fst.hier
+build/*
 
 # Compiled python files
 __pycache__/
@@ -59,3 +66,7 @@ firmware-bin
 # Never include unencrypted deploy keys.
 id_deploy
 id_deploy.pub
+
+# Artifacts dropped by `pdm install`
+.pdm-python
+pdm.lock

--- a/examples/hello-rust/firmware/.cargo/config.toml
+++ b/examples/hello-rust/firmware/.cargo/config.toml
@@ -1,0 +1,7 @@
+[target.riscv32imac-unknown-none-elf]
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "riscv32imac-unknown-none-elf"

--- a/examples/hello-rust/firmware/Cargo.toml
+++ b/examples/hello-rust/firmware/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.17"
-panic-halt = "0.2.0"
 riscv = { version = "=0.11.1", features = ["critical-section-single-hart"] }
 riscv-rt = { version = "=0.12.2", features = ["single-hart"] }
 

--- a/examples/hello-rust/firmware/Cargo.toml
+++ b/examples/hello-rust/firmware/Cargo.toml
@@ -17,6 +17,6 @@ default-features = false
 features = ["critical-section", "vexriscv"]
 
 [dependencies.lunasoc-hal]
-version = "0.2"
+path = "/home/seb/dev/cynthion/firmware/lunasoc-hal"
 default-features = false
 features = ["vexriscv"]

--- a/examples/hello-rust/firmware/Cargo.toml
+++ b/examples/hello-rust/firmware/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 panic-halt = "0.2.0"
-riscv = { version="=0.10.1",  features=["critical-section-single-hart"] }
-riscv-rt = "=0.11.0"
+riscv = { version = "=0.11.1", features = ["critical-section-single-hart"] }
+riscv-rt = { version = "=0.12.2", features = ["single-hart"] }
 
 [dependencies.lunasoc-pac]
 path = "../lunasoc-pac/"
@@ -17,6 +17,5 @@ default-features = false
 features = ["critical-section", "vexriscv"]
 
 [dependencies.lunasoc-hal]
-path = "/home/seb/dev/cynthion/firmware/lunasoc-hal"
+path = "../../../lunasoc-hal"
 default-features = false
-features = ["vexriscv"]

--- a/examples/hello-rust/firmware/src/log.rs
+++ b/examples/hello-rust/firmware/src/log.rs
@@ -51,8 +51,14 @@ where
             return;
         }
 
+        let color = match record.level() {
+            Level::Error => "31", // red
+            Level::Warn  => "33", // yellow
+            _            => "32", // green
+        };
+
         match self.writer.borrow_mut().as_mut() {
-            Some(writer) => match writeln!(writer, "{}\t{}", record.level(), record.args()) {
+            Some(writer) => match writeln!(writer, "[\x1B[{}m{}\x1B[0m] {}\r", color, record.level(), record.args()) {
                 Ok(()) => (),
                 Err(_e) => {
                     panic!("Logger failed to write to device");

--- a/examples/hello-rust/firmware/src/main.rs
+++ b/examples/hello-rust/firmware/src/main.rs
@@ -4,7 +4,7 @@
 use log::info;
 use panic_halt as _;
 use riscv_rt::entry;
-use lunasoc_hal::hal::delay::DelayUs;
+use lunasoc_hal::hal::delay::DelayNs;
 
 use firmware::{pac, hal};
 use hal::Serial0;
@@ -33,7 +33,7 @@ fn main() -> ! {
     info!("Peripherals initialized, entering main loop.");
 
     loop {
-        timer.delay_ms(100).unwrap();
+        timer.delay_ms(100);
 
         if direction {
             led_state >>= 1;

--- a/examples/hello-rust/firmware/src/main.rs
+++ b/examples/hello-rust/firmware/src/main.rs
@@ -2,7 +2,8 @@
 #![no_main]
 
 use log::info;
-use panic_halt as _;
+use log::error;
+use core::panic::PanicInfo;
 use riscv_rt::entry;
 use lunasoc_hal::hal::delay::DelayNs;
 
@@ -14,6 +15,26 @@ use hal::Timer0;
 unsafe fn pre_main() {
     pac::cpu::vexriscv::flush_icache();
     pac::cpu::vexriscv::flush_dcache();
+}
+
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(panic_info: &PanicInfo) -> ! {
+    if let Some(location) = panic_info.location() {
+        error!("panic(): file '{}' at line {}",
+            location.file(),
+            location.line(),
+        );
+    } else {
+        error!("panic(): no location information");
+    }
+    loop {}
+}
+
+#[export_name = "ExceptionHandler"]
+fn exception_handler(trap_frame: &riscv_rt::TrapFrame) -> ! {
+    error!("exception_handler(): TrapFrame.ra={:x}", trap_frame.ra);
+    loop {}
 }
 
 #[entry]

--- a/examples/hello-rust/top.py
+++ b/examples/hello-rust/top.py
@@ -120,7 +120,7 @@ class HelloSoc(wiring.Component):
         rust.PAC(svd_path).generate(pac_path=os.path.join(this_path, "lunasoc-pac"))
 
         logging.info("Building Rust firmware for SoC")
-        firmware_bin = os.path.join(this_path, build_dir, "firmware.bin")
+        firmware_bin = os.path.join(this_path, "firmware.bin")
         subprocess.check_call([
             "cargo", "build", "--release"
             ], env=os.environ, cwd=firmware_path)

--- a/examples/hello-rust/top.py
+++ b/examples/hello-rust/top.py
@@ -6,6 +6,7 @@
 
 import logging
 import os
+import subprocess
 import sys
 
 from luna                            import configure_default_logging
@@ -68,15 +69,8 @@ class HelloSoc(wiring.Component):
             features={"cti", "bte", "err"}
         )
 
-        # ... read our firmware binary ...
-        filename = "build/firmware.bin"
-        firmware = get_mem_data(filename, data_width=32, endianness="little")
-        if not firmware:
-            logging.warning(f"Firmware file '{filename}' could not be located.")
-            firmware = []
-
         # blockram
-        self.blockram = blockram.Peripheral(size=blockram_size, init=firmware)
+        self.blockram = blockram.Peripheral(size=blockram_size)
         self.wb_decoder.add(self.blockram.bus, addr=blockram_base, name="blockram")
 
         # csr decoder
@@ -102,9 +96,49 @@ class HelloSoc(wiring.Component):
         self.wb_to_csr = WishboneCSRBridge(self.csr_decoder.bus, data_width=32)
         self.wb_decoder.add(self.wb_to_csr.wb_bus, addr=csr_base, sparse=False, name="wb_to_csr")
 
+    def build(self, name, build_dir):
+
+        import shutil
+        from luna_soc.generate import rust, introspect, svd
+        memory_map = introspect.memory_map(self)
+        interrupts = introspect.interrupts(self)
+        reset_addr = introspect.reset_addr(self)
+
+        this_path = os.path.dirname(os.path.realpath(__file__))
+        firmware_path = os.path.join(this_path, "firmware")
+
+        logging.info("Generating Rust linker region info script for SoC")
+        with open(os.path.join(firmware_path, "../memory.x"), "w") as f:
+            rust.LinkerScript(memory_map, reset_addr).generate(file=f)
+
+        logging.info("Generating SVD description for SoC")
+        svd_path = os.path.join(this_path, f"{name}.svd")
+        with open(svd_path, "w") as f:
+            svd.SVD(memory_map, interrupts).generate(file=f)
+
+        logging.info("Generating Rust PAC for SoC")
+        rust.PAC(svd_path).generate(pac_path=os.path.join(this_path, "lunasoc-pac"))
+
+        logging.info("Building Rust firmware for SoC")
+        firmware_bin = os.path.join(this_path, build_dir, "firmware.bin")
+        subprocess.check_call([
+            "cargo", "build", "--release"
+            ], env=os.environ, cwd=firmware_path)
+        subprocess.check_call([
+            "cargo", "objcopy", "--release", "--", "-Obinary", firmware_bin
+            ], env=os.environ, cwd=firmware_path)
+
+        firmware = get_mem_data(firmware_bin, data_width=32, endianness="little")
+        if not firmware:
+            logging.error(f"Firmware file '{filename}' could not be located.")
+            exit(-1)
+        self.blockram.init = firmware
+
 
     def elaborate(self, platform):
         m = Module()
+
+        assert self.blockram.init
 
         # bus
         m.submodules += [self.wb_arbiter, self.wb_decoder]
@@ -173,7 +207,6 @@ class Top(Elaboratable):
         m.submodules += self.soc
 
         return m
-
 
 # - main ----------------------------------------------------------------------
 

--- a/luna_soc/gateware/core/spiflash/__init__.py
+++ b/luna_soc/gateware/core/spiflash/__init__.py
@@ -13,28 +13,9 @@ from amaranth.lib.wiring    import connect, In, Out
 from .port                  import SPIControlPortCDC, SPIControlPortCrossbar
 from .mmap                  import SPIFlashMemoryMap
 from .controller            import SPIController
-from .phy                   import SPIPHYController, ECP5ConfigurationFlashInterface
+from .phy                   import SPIPHYController, ECP5ConfigurationFlashProvider
 
-__all__ = ["PinSignature", "Peripheral", "ECP5ConfigurationFlashInterface", "SPIPHYController"]
-
-
-class PinSignature(wiring.Signature):
-    def __init__(self):
-        super().__init__({
-            "dq" : In(
-                wiring.Signature({
-                    "i"  :  In  (unsigned(4)),
-                    "o"  :  Out (unsigned(4)),
-                    "oe" :  Out (unsigned(1)),
-                })
-            ),
-            "cs" : Out(
-                wiring.Signature({
-                    "o"  :  Out (unsigned(1)),
-                })
-            ),
-        })
-
+__all__ = ["PinSignature", "Peripheral", "ECP5ConfigurationFlashProvider", "SPIPHYController"]
 
 class Peripheral(wiring.Component):
     """SPI Flash peripheral main module.
@@ -109,8 +90,8 @@ class Peripheral(wiring.Component):
             connect(m, phy_controller, cdc.a)
             connect(m, cdc.b, phy)
         else:
-            connect(m, phy_controller.source, phy.source)
-            connect(m, phy_controller.sink, phy.sink)
-            m.d.comb += phy.cs .eq(phy_controller.cs)
+            connect(m, phy_controller.source, phy.ctrl.source)
+            connect(m, phy_controller.sink, phy.ctrl.sink)
+            m.d.comb += phy.ctrl.cs.eq(phy_controller.cs)
 
         return m

--- a/luna_soc/gateware/core/spiflash/mmap.py
+++ b/luna_soc/gateware/core/spiflash/mmap.py
@@ -17,7 +17,7 @@ from amaranth_soc.memory                import MemoryMap
 from .port                              import SPIControlPort
 from .utils                             import WaitTimer
 
-from ....sim                            import is_hw
+from ....util.sim                       import is_hw
 
 
 class SPIFlashMemoryMap(wiring.Component):

--- a/luna_soc/gateware/core/spiflash/mmap.py
+++ b/luna_soc/gateware/core/spiflash/mmap.py
@@ -17,7 +17,7 @@ from amaranth_soc.memory                import MemoryMap
 from .port                              import SPIControlPort
 from .utils                             import WaitTimer
 
-from tiliqua.sim                        import is_hw
+from ....sim                            import is_hw
 
 
 class SPIFlashMemoryMap(wiring.Component):

--- a/luna_soc/gateware/core/spiflash/phy.py
+++ b/luna_soc/gateware/core/spiflash/phy.py
@@ -6,31 +6,84 @@
 
 # Based on code from LiteSPI
 
-from amaranth           import Elaboratable, Signal, Module, Cat, C, DomainRenamer, Instance
-from amaranth.lib       import wiring
-from amaranth.utils     import bits_for
+from amaranth               import *
+from amaranth.lib           import wiring
+from amaranth.utils         import bits_for
+from amaranth.lib.wiring    import connect, In, Out
 
 from .port              import SPIControlPort
 from .utils             import WaitTimer
 
+class SPIPinSignature(wiring.Signature):
+    def __init__(self):
+        super().__init__({
+            "dq" : Out(
+                wiring.Signature({
+                    "i"  :  In  (unsigned(4)),
+                    "o"  :  Out (unsigned(4)),
+                    "oe" :  Out (unsigned(1)),
+                })
+            ),
+            "cs" : Out(
+                wiring.Signature({
+                    "o"  :  Out (unsigned(1)),
+                })
+            ),
+            "sck" : Out(
+                wiring.Signature({
+                    "o"  :  Out (unsigned(1)),
+                })
+            ),
+        })
+
+class ECP5ConfigurationFlashProvider(wiring.Component):
+    """ Gateware that creates a connection to an MSPI configuration flash.
+
+    Automatically uses appropriate platform resources; this abstracts away details
+    necessary to e.g. drive the MCLK lines on an ECP5, which has special handling.
+    """
+    def __init__(self):
+        super().__init__({
+            "pins": In(SPIPinSignature())
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        spi = platform.request("qspi_flash")
+        m.d.comb += [
+            self.pins.dq.i.eq(spi.dq.i),
+            spi.dq.o.eq(self.pins.dq.o),
+            spi.dq.oe.eq(self.pins.dq.oe),
+            spi.cs.o.eq(self.pins.cs.o),
+        ]
+
+        # Get the ECP5 block that's responsible for driving the MCLK pin,
+        # and drive it using our SCK line.
+        user_mclk = Instance('USRMCLK', i_USRMCLKI=self.pins.sck.o, i_USRMCLKTS=0)
+        m.submodules += user_mclk
+
+        return m
 
 class SPIPHYController(wiring.Component):
     """Provides a generic PHY that can be used by a SPI flash controller.
 
     It supports single/dual/quad/octal output reads from the flash chips.
     """
-    def __init__(self, pads, data_width=32, divisor=0, domain="sync"):
-        super().__init__(SPIControlPort(data_width).flip())
-        self.divisor = divisor  # SPI frequency is clk / (2*(1+divisor))
-        self.pads    = pads
+    def __init__(self, data_width=32, divisor=0, domain="sync"):
+        super().__init__({
+            "ctrl": In(SPIControlPort(data_width)),
+            "pins": Out(SPIPinSignature()),
+        })
+        self.divisor = divisor
         self._domain = domain
 
     def elaborate(self, platform):
         m = Module()
 
-        pads   = self.pads
-        sink   = self.sink
-        source = self.source
+        pads   = self.pins
+        sink   = self.ctrl.sink
+        source = self.ctrl.source
 
         # Clock Generator.
         m.submodules.clkgen = clkgen = SPIClockGenerator(self.divisor, domain=self._domain)
@@ -42,18 +95,18 @@ class SPIPHYController(wiring.Component):
         if cs_delay > 0:
             m.submodules.cs_timer = cs_timer  = WaitTimer(cs_delay + 1, domain=self._domain)
             m.d.comb += [
-                cs_timer.wait    .eq(self.cs),
+                cs_timer.wait    .eq(self.ctrl.cs),
                 cs_enable        .eq(cs_timer.done),
             ]
         else:
-            m.d.comb += cs_enable.eq(self.cs)
+            m.d.comb += cs_enable.eq(self.ctrl.cs)
 
         # I/Os.
         dq_o  = Signal.like(pads.dq.o)
         dq_i  = Signal.like(pads.dq.i)
         dq_oe = Signal.like(pads.dq.oe)
         m.d.sync += [
-            pads.sck    .eq(clkgen.clk),
+            pads.sck.o  .eq(clkgen.clk),
             pads.cs.o   .eq(cs_enable),
             pads.dq.o   .eq(dq_o),
             pads.dq.oe  .eq(dq_oe),
@@ -211,36 +264,5 @@ class SPIClockGenerator(Elaboratable):
         # Convert our sync domain to the domain requested by the user, if necessary.
         if self._domain != "sync":
             m = DomainRenamer({"sync": self._domain})(m)
-
-        return m
-
-
-
-class ECP5ConfigurationFlashInterface(Elaboratable):
-    """ Gateware that creates a connection to an MSPI configuration flash.
-
-    Automatically uses appropriate platform resources; this abstracts away details
-    necessary to e.g. drive the MCLK lines on an ECP5, which has special handling.
-    """
-    def __init__(self, *, bus):
-        """ Params:
-            bus    -- The SPI bus object to extend.
-        """
-        self.bus    = bus
-        self.sck    = Signal()
-
-    def __getattr__(self, name):
-        try:
-            return getattr(self.bus, name)
-        except IndexError:
-            return object.__getattribute__(self, name)
-
-    def elaborate(self, platform):
-        m = Module()
-
-        # Get the ECP5 block that's responsible for driving the MCLK pin,
-        # and drive it using our SCK line.
-        user_mclk = Instance('USRMCLK', i_USRMCLKI=self.sck, i_USRMCLKTS=0)
-        m.submodules += user_mclk
 
         return m

--- a/luna_soc/gateware/cpu/__init__.py
+++ b/luna_soc/gateware/cpu/__init__.py
@@ -5,5 +5,4 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from .ic       import *
-from .minerva  import *
 from .vexriscv import *

--- a/luna_soc/generate/rust.py
+++ b/luna_soc/generate/rust.py
@@ -25,7 +25,7 @@ class LinkerScript:
 
         # TODO this should be determined by introspection
         memories = ["ram", "rom", "blockram", "spiflash",
-                    "bootrom", "scratchpad", "mainram"]
+                    "bootrom", "scratchpad", "mainram", "psram", "psram_xip"]
 
         # warning header
         emit("/*")
@@ -55,7 +55,12 @@ class LinkerScript:
 
         # region aliases
         ram = "blockram" if "blockram" in regions else "scratchpad"
-        rom = "spiflash" if "spiflash" in regions else ram
+        if "psram_xip" in regions:
+            rom = "psram_xip"
+        else if "spiflash" in regions:
+            rom = "spiflash"
+        else:
+            rom = ram
         aliases = {
             "REGION_TEXT":   rom,
             "REGION_RODATA": rom,

--- a/luna_soc/generate/rust.py
+++ b/luna_soc/generate/rust.py
@@ -57,7 +57,7 @@ class LinkerScript:
         ram = "blockram" if "blockram" in regions else "scratchpad"
         if "psram_xip" in regions:
             rom = "psram_xip"
-        else if "spiflash" in regions:
+        elif "spiflash" in regions:
             rom = "spiflash"
         else:
             rom = ram

--- a/luna_soc/generate/rust.py
+++ b/luna_soc/generate/rust.py
@@ -25,7 +25,7 @@ class LinkerScript:
 
         # TODO this should be determined by introspection
         memories = ["ram", "rom", "blockram", "spiflash",
-                    "bootrom", "scratchpad", "mainram", "psram", "psram_xip"]
+                    "bootrom", "scratchpad", "mainram", "psram"]
 
         # warning header
         emit("/*")
@@ -56,7 +56,7 @@ class LinkerScript:
         emit("}")
         emit("")
 
-        if xip_window is not None:
+        if xip_window is not None and reset_offset > 0:
             emit(f"_stext = ORIGIN({xip_window}) + {hex(reset_offset)};")
             emit("")
 

--- a/luna_soc/sim.py
+++ b/luna_soc/sim.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2024 S. Holzapfel <me@sebholzapfel.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Utilities for simulating Tiliqua designs."""
+
+import glob
+import os
+import shutil
+import subprocess
+
+from amaranth              import *
+from amaranth.back         import verilog
+from amaranth.build        import *
+from amaranth.lib          import wiring, data
+from amaranth.lib.wiring   import In, Out
+
+from amaranth_soc          import gpio
+
+def is_hw(platform):
+    # assumption: anything that inherits from Platform is a
+    # real hardware platform. Anything else isn't.
+    # is there a better way of doing this?
+    return isinstance(platform, Platform)
+
+class VerilatorPlatform():
+
+    class FakeDomainGenerator(Elaboratable):
+
+        def __init__(self, *, clock_frequencies=None, clock_signal_name=None):
+            pass
+
+        def elaborate(self, platform):
+            m = Module()
+
+            m.domains.sync   = ClockDomain()
+            m.domains.usb    = ClockDomain()
+            m.domains.fast   = ClockDomain()
+
+            return m
+
+    clock_domain_generator = FakeDomainGenerator
+
+    def __init__(self):
+        self.name = "verilator_platform"
+        self.files = {}
+
+    def has_required_tools(self):
+        return True
+
+    def add_file(self, file_name, contents):
+        if not file_name.endswith('.svh'):
+            self.files[file_name] = contents
+
+    def ports(self, fragment):
+        return {
+            "clk_sync":       (ClockSignal("sync"),                          None),
+            "rst_sync":       (ResetSignal("sync"),                          None),
+            "uart0_w_data":   (fragment.soc.uart0._tx_data.f.data.w_data,    None),
+            "uart0_w_stb":    (fragment.soc.uart0._tx_data.f.data.w_stb,     None),
+        }
+
+    def request(self, name, ix):
+        match name:
+            case "uart":
+                return wiring.Signature({
+                    "rx": In(wiring.Signature({"i": Out(unsigned(1))})),
+                    "tx": Out(wiring.Signature({"o": Out(unsigned(1))}))
+                    }).create()
+            case "led":
+                return wiring.Signature({"o": Out(unsigned(1))}).create()
+
+    def build(self, fragment, do_program, build_dir):
+
+        harness = "tb_cpp/sim_soc.cpp"
+
+        os.makedirs(build_dir, exist_ok=True)
+        verilog_dst = os.path.join(build_dir, "luna_soc.v")
+        with open(verilog_dst, "w") as f:
+            f.write(verilog.convert(
+                fragment,
+                platform=self,
+                ports=self.ports(fragment)
+                ))
+
+        # Write all additional files added with platform.add_file()
+        # to build/ directory, so verilator build can find them.
+        for file in self.files:
+            with open(os.path.join("build", file), "w") as f:
+                f.write(self.files[file])
+
+        tracing = True
+        tracing_flags = ["--trace-fst", "--trace-structs"] if tracing else []
+
+        verilator_dst = os.path.join(build_dir, "obj_dir")
+        shutil.rmtree(verilator_dst, ignore_errors=True)
+
+        # Copy shared testbench headers somewhere Verilator's build
+        # process can see them.
+        os.makedirs(verilator_dst)
+        testbench_utils = glob.glob("./src/tb_cpp/*.h")
+        for header in testbench_utils:
+            shutil.copy(header, verilator_dst)
+
+        print(f"verilate '{verilog_dst}' into C++ binary...")
+        subprocess.check_call(["verilator",
+                               "-Wno-COMBDLY",
+                               "-Wno-CASEINCOMPLETE",
+                               "-Wno-CASEOVERLAP",
+                               "-Wno-WIDTHEXPAND",
+                               "-Wno-WIDTHTRUNC",
+                               "-Wno-TIMESCALEMOD",
+                               "-Wno-PINMISSING",
+                               "-Wno-ASCRANGE",
+                               "-Wno-UNSIGNED",
+                               "-cc"] + tracing_flags + [
+                               "--exe",
+                               "--Mdir", f"{verilator_dst}",
+                               "-Ibuild",
+                               "--build",
+                               "-j", "0",
+                               "-CFLAGS", f"-DSYNC_CLK_HZ={fragment.clock_frequency_hz}",
+                               harness,
+                               f"{verilog_dst}",
+                              ] + [
+                                   f for f in self.files
+                                   if f.endswith(".svh") or f.endswith(".sv") or f.endswith(".v")
+                              ],
+                              env=os.environ)

--- a/luna_soc/util/sim.py
+++ b/luna_soc/util/sim.py
@@ -1,9 +1,11 @@
-# Copyright (c) 2024 S. Holzapfel <me@sebholzapfel.com>
 #
-# SPDX-License-Identifier: CERN-OHL-S-2.0
+# This file is part of LUNA.
 #
+# Copyright (c) 2025 S. Holzapfel <me@sebholzapfel.com>
+# Copyright (c) 2023-2025 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
 
-"""Utilities for simulating Tiliqua designs."""
+"""Utilities for simulating luna-soc designs with Verilator."""
 
 import glob
 import os
@@ -21,7 +23,7 @@ from amaranth_soc          import gpio
 def is_hw(platform):
     # assumption: anything that inherits from Platform is a
     # real hardware platform. Anything else isn't.
-    # is there a better way of doing this?
+    # is there a more idiomatic way of doing this?
     return isinstance(platform, Platform)
 
 class VerilatorPlatform():
@@ -35,8 +37,6 @@ class VerilatorPlatform():
             m = Module()
 
             m.domains.sync   = ClockDomain()
-            m.domains.usb    = ClockDomain()
-            m.domains.fast   = ClockDomain()
 
             return m
 
@@ -99,7 +99,7 @@ class VerilatorPlatform():
         # Copy shared testbench headers somewhere Verilator's build
         # process can see them.
         os.makedirs(verilator_dst)
-        testbench_utils = glob.glob("./src/tb_cpp/*.h")
+        testbench_utils = glob.glob("./tb_cpp/*.h")
         for header in testbench_utils:
             shutil.copy(header, verilator_dst)
 

--- a/lunasoc-hal/.cargo/config.toml
+++ b/lunasoc-hal/.cargo/config.toml
@@ -1,0 +1,19 @@
+[target.riscv32i-unknown-none-elf]
+runner = ".cargo/flash.sh"
+rustflags = [
+  "-C", "link-arg=-Tmemory.x",
+  "-C", "link-arg=-Tlink.x",
+]
+
+[target.riscv32imac-unknown-none-elf]
+runner = ".cargo/flash.sh"
+rustflags = [
+  "-C", "link-arg=-Tmemory.x",
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "riscv32imac-unknown-none-elf"
+
+[alias]
+test_linux = "test --target=x86_64-unknown-linux-gnu --features=log"

--- a/lunasoc-hal/Cargo.toml
+++ b/lunasoc-hal/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "lunasoc-hal"
+version = "0.0.0"
+categories = ["embedded", "hardware-support", "no-std"]
+edition = "2021"
+rust-version = "1.68"
+
+[package.metadata.docs.rs]
+default-target = "riscv32imac-unknown-none-elf"
+targets = [
+    "riscv32i-unknown-none-elf",
+    "riscv32imac-unknown-none-elf",
+]
+
+[lib]
+test = true
+bench = false
+
+[dependencies]
+embedded-hal = "=1.0.0"
+embedded-hal-nb = "=1.0.0"
+log = { version = "0.4.*", optional = true }
+nb = "=1.1.0"
+riscv = { version = "=0.11.1", features = ["critical-section-single-hart"] }
+embedded-graphics = "0.8.1"
+bitflags = "2.6.0"
+micromath = "2.1.0"
+
+[dev-dependencies]
+critical-section = { version = "1.1.2", features = ["std"] }
+env_logger = "0.11.6"

--- a/lunasoc-hal/LICENSE.txt
+++ b/lunasoc-hal/LICENSE.txt
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+Copyright (c) Antoine van Gelder <antoine@greatscottgadgets.com>
+Copyright (c) 2023, Great Scott Gadgets <info@greatscottgadgets.com>
+Copyright (c) 2024, S. Holzapfel <me@sebholzapfel.com>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lunasoc-hal/build.rs
+++ b/lunasoc-hal/build.rs
@@ -1,0 +1,24 @@
+use std::env;
+use std::str;
+
+fn main() {
+    // TODO Tracking Issue: https://github.com/rust-lang/rust/issues/94039
+    let Some(target) = rustc_target() else { return };
+    if target_has_atomic(&target) {
+        println!("cargo:rustc-cfg=target_has_atomic");
+    }
+
+    println!("cargo:rerun-if-changed=build.rs");
+}
+
+fn rustc_target() -> Option<String> {
+    env::var("TARGET").ok()
+}
+
+fn target_has_atomic(target: &str) -> bool {
+    match target {
+        "riscv32imac-unknown-none-elf" => true,
+        "riscv32i-unknown-none-elf" => false,
+        _ => false,
+    }
+}

--- a/lunasoc-hal/src/lib.rs
+++ b/lunasoc-hal/src/lib.rs
@@ -1,0 +1,19 @@
+#![cfg_attr(not(test), no_std)]
+#![allow(clippy::inline_always)]
+#![allow(clippy::must_use_candidate)]
+
+#[cfg(test)]
+#[macro_use]
+extern crate std;
+
+// modules
+pub mod serial;
+pub mod timer;
+
+pub use embedded_hal as hal;
+pub use embedded_hal_nb as hal_nb;
+
+#[macro_use]
+extern crate bitflags;
+
+pub use nb;

--- a/lunasoc-hal/src/serial.rs
+++ b/lunasoc-hal/src/serial.rs
@@ -1,0 +1,87 @@
+/// Re-export hal serial error type
+pub use crate::hal_nb::serial::ErrorKind as Error;
+
+#[macro_export]
+macro_rules! impl_serial {
+    ($(
+        $SERIALX:ident: $PACUARTX:ty,
+    )+) => {
+        $(
+            #[derive(Debug)]
+            pub struct $SERIALX {
+                registers: $PACUARTX,
+            }
+
+            // lifecycle
+            impl $SERIALX {
+                /// Create a new `Serial` from the [`UART`](crate::pac::UART) peripheral.
+                pub fn new(registers: $PACUARTX) -> Self {
+                    Self { registers }
+                }
+
+                /// Release the [`Uart`](crate::pac::UART) peripheral and consume self.
+                pub fn free(self) -> $PACUARTX {
+                    self.registers
+                }
+
+                /// Obtain a static `Serial` instance for use in e.g. interrupt handlers
+                ///
+                /// # Safety
+                ///
+                /// 'Tis thine responsibility, that which thou doth summon.
+                pub unsafe fn summon() -> Self {
+                    Self {
+                        registers: <$PACUARTX>::steal(),
+                    }
+                }
+            }
+
+            // trait: From
+            impl From<$PACUARTX> for $SERIALX {
+                fn from(registers: $PACUARTX) -> $SERIALX {
+                    $SERIALX::new(registers)
+                }
+            }
+
+            // trait: core::fmt::Write
+            impl core::fmt::Write for $SERIALX {
+                fn write_str(&mut self, s: &str) -> core::fmt::Result {
+                    use $crate::nb;
+                    use $crate::hal_nb::serial::Write;
+                    let _ = s
+                        .bytes()
+                        .map(|c| nb::block!(self.write(c)))
+                        .last();
+                    Ok(())
+                }
+            }
+
+            // - embedded_hal 1.0 traits --------------------------------------
+
+            // trait: hal_nb::serial::ErrorType
+            impl $crate::hal_nb::serial::ErrorType for $SERIALX {
+                type Error = $crate::serial::Error;
+            }
+
+            // trait: hal_nb::serial::Write
+            impl $crate::hal_nb::serial::Write for $SERIALX {
+                fn write(&mut self, byte: u8) -> $crate::nb::Result<(), Self::Error> {
+                    if self.registers.tx_ready().read().txe().bit() {
+                        self.registers.tx_data().write(|w| unsafe { w.data().bits(byte.into()) });
+                        Ok(())
+                    } else {
+                        Err($crate::nb::Error::WouldBlock)
+                    }
+                }
+
+                fn flush(&mut self) -> $crate::nb::Result<(), Self::Error> {
+                    if self.registers.tx_ready().read().txe().bit() {
+                        Ok(())
+                    } else {
+                        Err($crate::nb::Error::WouldBlock)
+                    }
+                }
+            }
+        )+
+    }
+}

--- a/lunasoc-hal/src/timer.rs
+++ b/lunasoc-hal/src/timer.rs
@@ -1,0 +1,172 @@
+/// Timer Events
+///
+/// Each event is a possible interrupt source, if enabled.
+pub enum Event {
+    /// Timer timed out / count down ended
+    TimeOut,
+}
+
+pub enum Mode {
+    OneShot,
+    Periodic,
+}
+
+#[macro_export]
+macro_rules! impl_timer {
+    ($(
+        $TIMERX:ident: $PACTIMERX:ty,
+    )+) => {
+        $(
+            /// Timer peripheral
+            #[derive(Debug)]
+            pub struct $TIMERX {
+                registers: $PACTIMERX,
+                /// System clock speed.
+                pub clk: u32,
+            }
+
+            // lifecycle
+            impl $TIMERX {
+                /// Create a new `Timer` from the [`TIMER`](crate::pac::TIMER) peripheral.
+                pub fn new(registers: $PACTIMERX, clk: u32) -> Self {
+                    Self { registers, clk }
+                }
+
+                /// Release the [`TIMER`](crate::pac::TIMER) peripheral and consume self.
+                pub fn free(self) -> $PACTIMERX {
+                    self.registers
+                }
+
+                /// Obtain a static `Timer` instance for use in e.g. interrupt handlers
+                ///
+                /// # Safety
+                ///
+                /// 'Tis thine responsibility, that which thou doth summon.
+                pub unsafe fn summon() -> Self {
+                    Self {
+                        registers: <$PACTIMERX>::steal(),
+                        clk: 0,
+                    }
+                }
+            }
+
+            // configuration
+            impl $TIMERX {
+                /// Current timer count
+                pub fn counter(&self) -> u32 {
+                    self.registers.counter().read().value().bits()
+                }
+
+                /// Disable timer
+                pub fn disable(&self) {
+                    self.registers.enable().write(|w| w.enable().bit(false));
+                }
+
+                /// Enable timer
+                pub fn enable(&self) {
+                    self.registers.enable().write(|w| w.enable().bit(true));
+                }
+
+                /// Set timeout using a [`core::time::Duration`]
+                pub fn set_timeout<T>(&mut self, timeout: T)
+                where
+                    T: Into<core::time::Duration>
+                {
+                    const NANOS_PER_SECOND: u64 = 1_000_000_000;
+                    let timeout = timeout.into();
+
+                    let clk = self.clk as u64;
+                    let ticks = u32::try_from(
+                        clk * timeout.as_secs() +
+                        clk * u64::from(timeout.subsec_nanos()) / NANOS_PER_SECOND,
+                    ).unwrap_or(u32::max_value());
+
+                    self.set_timeout_ticks(ticks.max(1));
+                }
+
+                /// Set timer mode
+                pub fn set_mode(&mut self, mode: $crate::timer::Mode) {
+                    let mode = match mode {
+                        $crate::timer::Mode::OneShot  => false,
+                        $crate::timer::Mode::Periodic => true,
+                    };
+                    self.registers.mode().write(|w| unsafe {
+                        w.periodic().bit(mode)
+                    });
+
+                }
+
+                /// Set timeout using system ticks
+                pub fn set_timeout_ticks(&mut self, ticks: u32) {
+                    self.registers.reload().write(|w| unsafe {
+                        w.value().bits(ticks)
+                    });
+                }
+            }
+
+            // interrupts
+            impl $TIMERX {
+
+                /// Start listening for [`Event`]
+                pub fn listen(&mut self, event: $crate::timer::Event) {
+                    match event {
+                        $crate::timer::Event::TimeOut => {
+                            self.registers.ev_enable().write(|w| unsafe { w.mask().bit(true) });
+                        }
+                    }
+                }
+
+                /// Stop listening for [`Event`]
+                pub fn unlisten(&mut self, event: $crate::timer::Event) {
+                    match event {
+                        $crate::timer::Event::TimeOut => {
+                            self.registers.ev_enable().write(|w| unsafe { w.mask().bit(false) });
+                        }
+                    }
+                }
+
+                /// Check if the interrupt flag is pending
+                pub fn is_pending(&self) -> bool {
+                    self.registers.ev_pending().read().mask().bit()
+                }
+
+                /// Clear the interrupt flag
+                pub fn clear_pending(&self) {
+                    self.registers.ev_pending().modify(|r, w| unsafe { w.mask().bit(r.mask().bit()) });
+                }
+
+                pub fn enable_tick_isr(&mut self, period_ms: u32, isr: pac::Interrupt) {
+                    use core::time::Duration;
+                    use lunasoc_hal::timer::Event;
+                    self.disable();
+                    self.listen(Event::TimeOut);
+                    self.set_mode($crate::timer::Mode::Periodic);
+                    self.set_timeout(Duration::from_millis(period_ms.into()));
+                    self.enable();
+                    unsafe {
+                            pac::csr::interrupt::enable(isr);
+                            riscv::register::mie::set_mext();
+                            riscv::interrupt::enable();
+                    }
+                }
+            }
+
+            impl $crate::hal::delay::DelayNs for $TIMERX {
+                fn delay_ns(&mut self, ns: u32) {
+                    let ticks: u32 = (self.clk / 1_000_000) * (ns / 1_000);
+
+                    // reset timer
+                    self.registers.enable().write(|w| w.enable().bit(false));
+
+                    // start timer
+                    self.set_mode($crate::timer::Mode::OneShot);
+                    self.registers.reload().write(|w| unsafe { w.value().bits(ticks) });
+                    self.registers.enable().write(|w| w.enable().bit(true));
+
+                    // wait for timer to hit zero
+                    while self.registers.counter().read().value().bits() != 0 {}
+                }
+            }
+        )+
+    }
+}

--- a/tb_cpp/sim_soc.cpp
+++ b/tb_cpp/sim_soc.cpp
@@ -1,0 +1,74 @@
+// A (quite dirty) simulation harness that simulates the luna_soc core
+// and uses it to generate some full FST traces for examination.
+
+#include <cmath>
+
+#if VM_TRACE_FST == 1
+#include <verilated_fst_c.h>
+#endif
+
+#include "Vluna_soc.h"
+#include "verilated.h"
+
+#include <fstream>
+
+int main(int argc, char** argv) {
+    VerilatedContext* contextp = new VerilatedContext;
+    contextp->commandArgs(argc, argv);
+    Vluna_soc* top = new Vluna_soc{contextp};
+
+#if VM_TRACE_FST == 1
+    Verilated::traceEverOn(true);
+    VerilatedFstC* tfp = new VerilatedFstC;
+    top->trace(tfp, 99);  // Trace 99 levels of hierarchy (or see below)
+    tfp->open("simx.fst");
+#endif
+
+    uint64_t sim_time =  5000e9;
+
+    uint64_t ns_in_s = 1e9;
+    uint64_t ns_in_sync_cycle   = ns_in_s /  SYNC_CLK_HZ;
+    printf("sync domain is: %i KHz (%i ns/cycle)\n",  SYNC_CLK_HZ/1000,  ns_in_sync_cycle);
+
+    contextp->timeInc(1);
+    top->rst_sync = 1;
+    top->eval();
+
+#if VM_TRACE_FST == 1
+    tfp->dump(contextp->time());
+#endif
+
+    contextp->timeInc(1);
+    top->rst_sync = 0;
+    top->eval();
+
+#if VM_TRACE_FST == 1
+    tfp->dump(contextp->time());
+#endif
+
+    while (contextp->time() < sim_time && !contextp->gotFinish()) {
+
+        uint64_t timestamp_ns = contextp->time() / 1000;
+
+        // Sync clock domain (PSRAM read/write simulation, UART printouts)
+        if (timestamp_ns % (ns_in_sync_cycle/2) == 0) {
+            top->clk_sync = !top->clk_sync;
+            top->eval();
+            if (top->clk_sync) {
+                if (top->uart0_w_stb) {
+                    putchar(top->uart0_w_data);
+                }
+            }
+        }
+
+        contextp->timeInc(1000);
+        top->eval();
+#if VM_TRACE_FST == 1
+        tfp->dump(contextp->time());
+#endif
+    }
+#if VM_TRACE_FST == 1
+    tfp->close();
+#endif
+    return 0;
+}

--- a/tb_cpp/sim_soc.cpp
+++ b/tb_cpp/sim_soc.cpp
@@ -1,4 +1,4 @@
-// A (quite dirty) simulation harness that simulates the luna_soc core
+// A very simple simulation harness that simulates the luna_soc core
 // and uses it to generate some full FST traces for examination.
 
 #include <cmath>
@@ -13,6 +13,7 @@
 #include <fstream>
 
 int main(int argc, char** argv) {
+
     VerilatedContext* contextp = new VerilatedContext;
     contextp->commandArgs(argc, argv);
     Vluna_soc* top = new Vluna_soc{contextp};
@@ -20,27 +21,19 @@ int main(int argc, char** argv) {
 #if VM_TRACE_FST == 1
     Verilated::traceEverOn(true);
     VerilatedFstC* tfp = new VerilatedFstC;
-    top->trace(tfp, 99);  // Trace 99 levels of hierarchy (or see below)
-    tfp->open("simx.fst");
+    top->trace(tfp, 99);
+    tfp->open("sim_soc.fst");
 #endif
 
-    uint64_t sim_time =  5000e9;
+    uint64_t sim_time = 5000e9;
+    uint64_t n_cycles = 0;
+    uint64_t n_reset_clocks = 1;
 
     uint64_t ns_in_s = 1e9;
     uint64_t ns_in_sync_cycle   = ns_in_s /  SYNC_CLK_HZ;
     printf("sync domain is: %i KHz (%i ns/cycle)\n",  SYNC_CLK_HZ/1000,  ns_in_sync_cycle);
 
-    contextp->timeInc(1);
     top->rst_sync = 1;
-    top->eval();
-
-#if VM_TRACE_FST == 1
-    tfp->dump(contextp->time());
-#endif
-
-    contextp->timeInc(1);
-    top->rst_sync = 0;
-    top->eval();
 
 #if VM_TRACE_FST == 1
     tfp->dump(contextp->time());
@@ -50,25 +43,32 @@ int main(int argc, char** argv) {
 
         uint64_t timestamp_ns = contextp->time() / 1000;
 
-        // Sync clock domain (PSRAM read/write simulation, UART printouts)
         if (timestamp_ns % (ns_in_sync_cycle/2) == 0) {
             top->clk_sync = !top->clk_sync;
             top->eval();
             if (top->clk_sync) {
+                n_cycles += 1;
                 if (top->uart0_w_stb) {
                     putchar(top->uart0_w_data);
+                }
+                if (n_cycles > n_reset_clocks) {
+                    top->rst_sync = 0;
                 }
             }
         }
 
         contextp->timeInc(1000);
         top->eval();
+
 #if VM_TRACE_FST == 1
         tfp->dump(contextp->time());
 #endif
+
     }
+
 #if VM_TRACE_FST == 1
     tfp->close();
 #endif
+
     return 0;
 }


### PR DESCRIPTION
This is a WIP, aim is to try and upstream some quality-of-life things from Tiliqua's `luna-soc` fork. More work is needed, just putting this up for some early comments at the moment.

Main change is to add a `VerilatorPlatform`, which can be used to run `example-rust`, and move away from the `Makefile` based build system so that `luna-soc` bitstreams / firmware images can be built in a single CLI action.

In Yosys land,`cxxrtl` would arguably be a more idiomatic simulator, as Yosys can directly emit `cxxrtl`, however in my testing Verilator has been able to simulate my bitstreams >2x faster. So there is a tradeoff to be had there, but it is entirely possible I was missing some magic flags.

At the moment this PR collects a few somewhat-related things but happy to split into separate PRs if necessary:
- Add `util/sim` simulation backend. An example invocation (here I launch with pdm but you don't need to):
```
LUNA_PLATFORM=luna_soc.util.sim:VerilatorPlatform pdm run examples/hello-rust/top.py --dry-run --keep-files
# ... everything including firmware is built in a single step, binary can then be run with
./build/obj_dir/Vluna_soc
```

![Screenshot_select-area_20250421154903](https://github.com/user-attachments/assets/b8b91faf-1ef7-4471-a765-84a7d3d442ec)

- Make some changes to the `spiflash` core, such that it exposes a simulation interface (for injecting 'fake' firmware that's in the `spiflash`). Also, refactor the pin provider so that it behaves like a real provider and we can instantiate the full `spiflash` core without needing a `platform.request`. It would be nice to simulate this at the IO level instead of requiring white-box injection, but that would require considerably more effort, not sure if it's worth it.
- Use `_stext` to allow the reset address to be in any memory region. This makes it possible to put `.text` in spiflash, block ram or psram without needing to hardcode the names of each region.
- Move away from the `make` based build system for the rust example such that a whole system can be built in one CLI invocation.
- Make some improvements to `panic`, `exception_handler` and `logger` for more verbose errors and colors.
- Move shared parts of `lunasoc-hal` in-tree, bump `embedded-hal` to v1.0.0 as well as some other dependencies. I hope we can move `lunasoc-hal` in-tree here and then maybe remove the redundant parts from `cynthion`?

TODO/MAYBE:
- Allow running `hello-rust` on VerilatorPlatform with firmware in XiP spiflash (currently only the default bram config is supported)
- Allow running `hello-c` on VerilatorPlatform, also in a single CLI action (currently completely unsupported)
- Add a github action to verify the simulation spits out the UART prints we expect
- Modify `top_level_cli` to allow passing `--sim` or `--trace-fst` which would execute the compiled binary straight after compiling it (without or with fst tracing)
- Figure out a nice way of moving the SoC build steps from hello-rust/top.py up into `luna-soc` proper.
- Add more command line arguments to `sim_soc.cpp` harness (for example, simulation time, clock rate and so on) that are transparently passed through. This could be quite useful e.g. for integration tests where we want to halt execution after a short time.
- Figure out a better way to store `lunasoc-pac` before the generated code is put inside it. Maybe this could exist as a template folder that is copied into the destination project before the SVF is used to populate the generated files. Not sure if this would actually be cleaner though.