### PR TITLE
core: fix event trigger modes

### DIFF
--- a/luna_soc/gateware/core/ila.py
+++ b/luna_soc/gateware/core/ila.py
@@ -8,7 +8,7 @@ from amaranth              import *
 from amaranth.lib          import enum, wiring
 from amaranth.lib.wiring   import In, Out, flipped, connect
 
-from amaranth_soc          import csr, event
+from amaranth_soc          import csr
 
 
 class Peripheral(wiring.Component):

--- a/luna_soc/gateware/core/timer.py
+++ b/luna_soc/gateware/core/timer.py
@@ -56,8 +56,8 @@ class Peripheral(wiring.Component):
 
         # events
         from typing import Annotated
-        ResetSource = Annotated[event.Source, "Interrupt that occurs when the timer reaches zero."]
-        self._zero = ResetSource(path=("zero",))
+        EventSource = Annotated[event.Source, "Interrupt that occurs when the timer reaches zero."]
+        self._zero = EventSource(trigger="rise", path=("zero",))
         event_map = event.EventMap()
         event_map.add(self._zero)
         self._events = csr.event.EventMonitor(event_map, data_width=8)

--- a/luna_soc/gateware/core/usb2/device.py
+++ b/luna_soc/gateware/core/usb2/device.py
@@ -75,7 +75,7 @@ class Peripheral(wiring.Component):
 
         # events
         EventSource = Annotated[event.Source, "Interrupt that occurs when a USB bus reset is received."]
-        self._reset = EventSource(path=("reset",))
+        self._reset = EventSource(trigger="rise", path=("reset",))
         event_map = event.EventMap()
         event_map.add(self._reset)
         self._events = csr.event.EventMonitor(event_map, data_width=8)

--- a/luna_soc/gateware/core/usb2/ep_control.py
+++ b/luna_soc/gateware/core/usb2/ep_control.py
@@ -94,7 +94,7 @@ class Peripheral(wiring.Component):
         # events
         from typing import Annotated
         EventSource = Annotated[event.Source, "Interrupt that triggers when a new SETUP packet is ready to be read."]
-        self._setup_received = EventSource(path=("setup_received",))
+        self._setup_received = EventSource(trigger="rise", path=("setup_received",))
         event_map = event.EventMap()
         event_map.add(self._setup_received)
         self._events = csr.event.EventMonitor(event_map, data_width=8)

--- a/luna_soc/gateware/core/usb2/ep_in.py
+++ b/luna_soc/gateware/core/usb2/ep_in.py
@@ -132,7 +132,7 @@ class Peripheral(wiring.Component):
 
         # events
         EventSource = Annotated[event.Source, "Indicates that the host has successfully transferred an ``IN`` packet, and that the FIFO is now empty."]
-        self._done = EventSource(path=("done",))
+        self._done = EventSource(trigger="rise", path=("done",))
         event_map = event.EventMap()
         event_map.add(self._done)
         self._events = csr.event.EventMonitor(event_map, data_width=8)

--- a/luna_soc/gateware/core/usb2/ep_out.py
+++ b/luna_soc/gateware/core/usb2/ep_out.py
@@ -169,7 +169,7 @@ class Peripheral(wiring.Component):
 
         # events
         EventSource = Annotated[event.Source, "Indicates that an ``OUT`` packet has successfully been transferred from the host. This bit must be cleared in order to receive additional packets."]
-        self._done = EventSource(path=("done",))
+        self._done = EventSource(trigger="rise", path=("done",))
         event_map = event.EventMap()
         event_map.add(self._done)
         self._events = csr.event.EventMonitor(event_map, data_width=8)


### PR DESCRIPTION
The `amaranth-soc` event Source uses a level-triggered mode of operation by default. This PR sets the mode to be edge-triggered on the rising edge.

---

closes #44 